### PR TITLE
Avoid NRE while checking if type is plugin

### DIFF
--- a/src/SolutionGenerator/Extensibility/PluginFinder.cs
+++ b/src/SolutionGenerator/Extensibility/PluginFinder.cs
@@ -63,7 +63,7 @@ namespace SolutionGenerator.Extensibility
         {
             // Note: we are in reflection only context here, we must check against the name, not the type
             if ((from iface in type.GetInterfacesEx()
-                 where iface.FullName.Equals(ExpectedInterfaceName)
+                 where string.Equals(iface.FullName, ExpectedInterfaceName)
                  select iface).Any())
             {
                 return true;


### PR DESCRIPTION
While starting SolutionGenerator I found a NullReferenceException:

at SolutionGenerator.Extensibility.PluginFinder.<>c.<IsPlugin>b__3_0(Type iface) in C:\SolutionGenerator\src\SolutionGenerator\Extensibility\PluginFinder.cs:line 66
   at System.Linq.Enumerable.WhereArrayIterator`1.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
   at SolutionGenerator.Extensibility.PluginFinder.IsPlugin(Type type) in C:\SolutionGenerator\src\SolutionGenerator\Extensibility\PluginFinder.cs:line 65
   at Orc.Extensibility.PluginFinderBase.<FindPluginsInAssembly>b__11_0(Type type) in C:\CI_WS\Ws\92575\Source\Orc_Extensibility\src\Orc.Extensibility\Orc.Extensibility.Shared\Services\PluginFinderBase.cs:line 208
   at System.Linq.Enumerable.WhereArrayIterator`1.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Orc.Extensibility.PluginFinderBase.FindPluginsInAssembly(Assembly assembly) in C:\CI_WS\Ws\92575\Source\Orc_Extensibility\src\Orc.Extensibility\Orc.Extensibility.Shared\Services\PluginFinderBase.cs:line 207

I found that it's possible that type.FullName can be null.
Article here: https://blogs.msdn.microsoft.com/haibo_luo/2006/02/17/type-fullname-returns-null-when/

To avoid this we can simply use string.Equals.